### PR TITLE
Adding the logging middleware

### DIFF
--- a/bot/scripts/logging_middleware.coffee
+++ b/bot/scripts/logging_middleware.coffee
@@ -1,7 +1,7 @@
 module.exports = (robot) ->
   robot.receiveMiddleware (context, next, done) ->
-    if context.response.message != undefined and context.response.message.user != undefined and context.response.message.text != undefined and context.response.message.text?.match(robot.respondPattern(''))
-      robot.logger.info "MESSAGE RECEIVED #{context.response.message.user.name} : #{context.response.message.text}"
+    if context.response.message != undefined and context.response.message.text?.match(robot.respondPattern(''))
+      robot.logger.info "MESSAGE RECEIVED #{context.response.message.user.name} in #{context.response.message.room} : #{context.response.message.text}"
     next()
 
   robot.responseMiddleware (context, next, done) ->

--- a/bot/scripts/logging_middleware.coffee
+++ b/bot/scripts/logging_middleware.coffee
@@ -5,7 +5,7 @@ module.exports = (robot) ->
     next()
 
   robot.responseMiddleware (context, next, done) ->
-    if context.response.message != undefined and context.response.message.user != undefined and context.response.message.text != undefined
+    if context.strings != undefined
       sanitized_strings = x.replace(/\r?\n|\r/g, "\\n") for x in context.strings
       robot.logger.info "MESSAGE RESPONDED Hubot : #{sanitized_strings}"
     next()

--- a/bot/scripts/logging_middleware.coffee
+++ b/bot/scripts/logging_middleware.coffee
@@ -1,0 +1,12 @@
+module.exports = (robot) ->
+  robot.receiveMiddleware (context, next, done) ->
+    if context.response.message != undefined and context.response.message.user != undefined and context.response.message.text != undefined and context.response.message.text?.match(robot.respondPattern(''))
+      robot.logger.info "MESSAGE RECEIVED #{context.response.message.user.name} : #{context.response.message.text}"
+    next()
+
+  robot.responseMiddleware (context, next, done) ->
+    if context.response.message != undefined and context.response.message.user != undefined and context.response.message.text != undefined
+      sanitized_strings = x.replace(/\r?\n|\r/g, "\\n") for x in context.strings
+      robot.logger.info "MESSAGE RESPONDED Hubot : #{sanitized_strings}"
+    next()
+


### PR DESCRIPTION
@matefh @saher.neklawy

That's a middleware to intercept incoming and outcoming messages and logs it to the default logger.
- It will ignore messages that are not directed to hubot.
- Will escape newlines to keep the log as a line per message.